### PR TITLE
Changed the UITextView tint color to yellow.

### DIFF
--- a/PCSA/PCSA/Base.lproj/Main.storyboard
+++ b/PCSA/PCSA/Base.lproj/Main.storyboard
@@ -2590,6 +2590,7 @@ Located in-country, at post.</string>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="daT-GD-hje" userLabel="Description">
                                                                 <rect key="frame" x="8" y="43" width="464" height="396"/>
+                                                                <color key="tintColor" red="0.99868744610000004" green="0.74952501059999999" blue="0.33808326719999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <string key="text">The PC SAVES Helpline provides anonymous, confidential crisis intervention, support, and information via a call, text, or online chat to Peace Corps Volunteers and Trainees. All options are staffed by trained professionals not affiliated with Peace Corps, available 24/7.  No personally identifying information will be collected. 
 
 Online Chat: pcsaveshelpline.org</string>
@@ -2660,6 +2661,7 @@ Online Chat: pcsaveshelpline.org</string>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="1h5-P5-CtR" userLabel="Description">
                                                                 <rect key="frame" x="8" y="43" width="464" height="396"/>
+                                                                <color key="tintColor" red="0.99868744610000004" green="0.74952501059999999" blue="0.33808326719999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <string key="text">Victim Advocates are available for Volunteers who are victims of crimes. They can provide information regarding available response services, address questions/concerns, and ensure their voices are heard and considered in all decisions affecting service and care.
 
 E-mail: victimadvocate@peacecorps.gov</string>
@@ -2728,6 +2730,7 @@ E-mail: victimadvocate@peacecorps.gov</string>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="cLR-j4-qez" userLabel="Description">
                                                                 <rect key="frame" x="8" y="43" width="464" height="396"/>
+                                                                <color key="tintColor" red="0.99868744610000004" green="0.74952501059999999" blue="0.33808326719999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <string key="text">OIG is a resource for those who have been harmed by misconduct or criminal wrongdoing by a fellow Volunteer or Peace Corps Staff.  They are independent from Peace Corps with law enforcement officers who have the unique authorities to help seek a fair resolution and, in appropriate cases, to seek prosecution in the United States or host country.  
 
 Learn more: peacecorps.gov/OIG
@@ -2798,6 +2801,7 @@ Email: oig@peacecorps.gov</string>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="b9K-2r-zhi" userLabel="Description">
                                                                 <rect key="frame" x="8" y="43" width="464" height="396"/>
+                                                                <color key="tintColor" red="0.99868744610000004" green="0.74952501059999999" blue="0.33808326719999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <string key="text">Resource to provide leadership and guidance on all civil rights, equal employment opportunity and diversity matters; and to address issues of discrimination and harassment, including sexual harassment, in the recruitment/service of Volunteers/Trainees.
 
 Email: ocrd@peacecorps.gov</string>


### PR DESCRIPTION
The only screen that has links/email links/phone numbers is the Get Help Now screen. So I've changed the `tintColor` to yellow, so it's more visible on the green background.

### The links now look like this:
<img width="250" src="http://i.imgur.com/KAw1ats.png">